### PR TITLE
added toHex to REPL's context

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,6 +1,6 @@
-import {Anix} from '../src/anix.js'
+import {Anix} from '../src/anix.mjs'
 
 const eth = new Anix('eth', process.env.ENDPOINT_HTTP)
 
 console.dir(await eth.getBlockByNumber('latest', false))
-
+console.dir(await web3.sha3('blablabla'))

--- a/src/anix.repl.mjs
+++ b/src/anix.repl.mjs
@@ -32,3 +32,5 @@ const r = repl.start({
     Object.defineProperty(r.context, namespace, { value: anix, configurable: false, enumerable: true })
 }
 )
+
+Object.defineProperty(r.context, 'toHex', { value: toHex, configurable: false, enumerable: true })


### PR DESCRIPTION
Practising the examples, I noticed that toHex was not accessible from the REPL. 
There may be better solutions, but this one seems to work. 

Congrats on this efficient tool